### PR TITLE
Remove unreleasedLabel field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           pullRequests: true
           prWoLabels: true
           unreleased: true
-          unreleasedLabel: true
           addSections: '{"documentation":{"prefix":"**Documentation:**","labels":["documentation"]}}'
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
Follow up for #10 

Remove `unreleasedLabel` field from the `changelog_prerelease` job.

I had assume that it was necessary to get the the unreleased section to be printed, but it is for specifying the name of section instead (which defaults to **Unrealeased**)