### PR TITLE
Retry for new access token

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camp3 (0.0.1)
+    camp3 (0.0.2)
       httparty (~> 0.18)
       rack-oauth2 (~> 1.14)
 

--- a/examples/messages.rb
+++ b/examples/messages.rb
@@ -8,15 +8,19 @@ Camp3.configure do |config|
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
 
-projects = Camp3.projects
+client = Camp3.client
+
+projects = client.projects
+
+puts projects
 
 projects.each do |p|
   puts "Project: #{p.name}"
 
-  message_board = Camp3.message_board(p)
+  message_board = client.message_board(p)
   puts "Message Board: #{message_board.title}"
 
-  messages = Camp3.messages(message_board)
+  messages = client.messages(message_board)
 
   messages.each do |msg|
     puts msg.inspect

--- a/examples/messages.rb
+++ b/examples/messages.rb
@@ -10,8 +10,6 @@ end
 
 projects = Camp3.projects
 
-puts projects
-
 projects.each do |p|
   puts "Project: #{p.name}"
 

--- a/examples/messages.rb
+++ b/examples/messages.rb
@@ -8,19 +8,17 @@ Camp3.configure do |config|
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
 
-client = Camp3.client
-
-projects = client.projects
+projects = Camp3.projects
 
 puts projects
 
 projects.each do |p|
   puts "Project: #{p.name}"
 
-  message_board = client.message_board(p)
+  message_board = Camp3.message_board(p)
   puts "Message Board: #{message_board.title}"
 
-  messages = client.messages(message_board)
+  messages = Camp3.messages(message_board)
 
   messages.each do |msg|
     puts msg.inspect

--- a/lib/camp3.rb
+++ b/lib/camp3.rb
@@ -17,30 +17,6 @@ module Camp3
   extend Logging
   extend Configuration
 
-  # def self.authorize!(auth_code)
-  #   tokens = client.authorize!(auth_code)
-
-  #   Resource.configure(Camp3.access_token)
-
-  #   tokens
-  # end
-
-  # def self.update_access_token!(refresh_token = nil)
-  #   refresh_token = Camp3.refresh_token unless refresh_token
-    
-  #   tokens = client.update_access_token!(refresh_token)
-
-  #   Resource.configure(Camp3.access_token)
-
-  #   tokens
-  # end
-
-  # def self.configure
-  #   yield self
-
-  #   Resource.configure(Camp3.access_token) if Camp3.access_token
-  # end
-
   # Alias for Camp3::Client.new
   #
   # @return [Camp3::Client]

--- a/lib/camp3/authorization.rb
+++ b/lib/camp3/authorization.rb
@@ -59,8 +59,8 @@ module Camp3
     private
 
     def store_tokens(token)
-      Camp3.access_token = token.access_token
-      Camp3.refresh_token = token.refresh_token
+      @access_token = token.access_token
+      @refresh_token = token.refresh_token
     end
   end
 end

--- a/lib/camp3/request.rb
+++ b/lib/camp3/request.rb
@@ -11,6 +11,18 @@ module Camp3
 
     attr_accessor :access_token
 
+    module Result
+      AccessTokenExpired = 'AccessTokenExpired'
+
+      Valid = 'Valid'
+    end
+
+    def initialize(access_token, user_agent)
+      @access_token = access_token
+
+      self.class.headers 'User-Agent' => user_agent
+    end
+
     # Converts the response body to a Resource.
     def self.parse(body)
       body = decode(body)
@@ -39,31 +51,56 @@ module Camp3
 
     %w[get post put delete].each do |method|
       define_method method do |path, options = {}|
-        override_path = options.delete(:override_path)
         params = options.dup
-
+        override_path = params.delete(:override_path)
+        
         params[:headers] ||= {}
-        params[:headers].merge!(authorization_header)
 
         full_endpoint = override_path ? path : Camp3.api_endpoint + path
 
-        validate self.class.send(method, full_endpoint, params)
+        execute_request(method, full_endpoint, params)
       end
     end
 
-    # Checks the response code for common errors.
-    # Returns parsed response for successful requests.
-    def validate(response)
-      error_klass = Error::STATUS_MAPPINGS[response.code]
-      raise error_klass, response if error_klass
+    private
 
-      parsed = self.class.parse(response)
-      parsed.client = self if parsed.respond_to?(:client=)
-      parsed.parse_headers!(response.headers) if parsed.respond_to?(:parse_headers!)
-      parsed
+    # Executes the request
+    def execute_request(method, endpoint, params)
+      params[:headers].merge!(authorization_header)
+      
+      Camp3.logger.debug("Method: #{method}; URL: #{endpoint}; Params: #{params}")
+      response, result = validate self.class.send(method, endpoint, params)
+
+      response = parse(response) if result == Result::Valid
+
+      return response, result
     end
 
-    private
+    # Checks the response code for common errors.
+    # Informs that a retry needs to happen if request failed due to access token expiration
+    # @raise [Error::ResponseError] if response is an HTTP error
+    # @return [Response, Request::Result]
+    def validate(response)
+      error_klass = Error::STATUS_MAPPINGS[response.code]
+
+      if error_klass == Error::Unauthorized && response.parsed_response.include?("OAuth token expired (old age)")
+        Camp3.logger.debug("Access token expired. Please obtain a new access token")
+        return response, Result::AccessTokenExpired
+      end
+
+      raise error_klass, response if error_klass
+
+      return response, Result::Valid
+    end
+
+    def parse(response)
+      parsed = self.class.parse(response)
+      
+      parsed.client = self if parsed.respond_to?(:client=)
+      parsed.parse_headers!(response.headers) if parsed.respond_to?(:parse_headers!)
+
+      parsed
+    end
 
     # Returns an Authorization header hash
     #

--- a/lib/camp3/resource.rb
+++ b/lib/camp3/resource.rb
@@ -63,7 +63,7 @@ module Camp3
 
     def self.detect_type(url)
       case url
-      when /#{Camp3.api_endpoint}\/projects\/\d+\.json/
+      when /#{Camp3.base_api_endpoint}\/\d+\/projects\/\d+\.json/
         return Project
       else
         return Resource

--- a/lib/camp3/resource.rb
+++ b/lib/camp3/resource.rb
@@ -62,7 +62,6 @@ module Camp3
     end
 
     def self.detect_type(url)
-      Camp3.logger.debug "Request URL: #{url}" 
       case url
       when /#{Camp3.api_endpoint}\/projects\/\d+\.json/
         return Project

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Camp3::Request do
+  before do
+    @request = described_class.new('token', 'user-agent')
+  end
+
+  it { expect(@request).to respond_to :get }
+  it { expect(@request).to respond_to :post }
+  it { expect(@request).to respond_to :put }
+  it { expect(@request).to respond_to :delete }
+
+  describe '.default_options' do
+    it 'has default values' do
+      default_options = described_class.default_options
+      expect(default_options).to be_a Hash
+      expect(default_options[:format]).to eq(:json)
+      expect(default_options[:headers]).to eq({'Accept' => 'application/json', 'User-Agent' => 'user-agent'})
+    end
+  end
+
+  describe '.parse' do
+    it 'returns Resource' do
+      body = JSON.unparse(a: 1, b: 2)
+      expect(described_class.parse(body)).to be_an Camp3::Resource
+      expect(described_class.parse('true')).to be true
+      expect(described_class.parse('false')).to be false
+
+      expect { described_class.parse('string') }.to raise_error(Camp3::Error::Parsing)
+    end
+  end
+
+  describe '#authorization_header' do
+    it 'raises MissingCredentials when access_token is not set' do
+      request = described_class.new('', 'user-agent')
+      expect do
+        request.send(:authorization_header)
+      end.to raise_error(Camp3::Error::MissingCredentials)
+    end
+
+    it 'sets the correct header when given a private_token' do
+      expect(@request.send(:authorization_header)).to eq('Authorization' => "Bearer token")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fix #13 

Adds a new step to retry a request if the original request is detected to be failed due to access token being expired.

### Example

Running the *messages.rb* in the examples folder in debug mode shows the following:

```bash
$ dotenv bundle exec ruby ./examples/messages.rb
D, [2020-07-21T13:33:29.236187 #11357] DEBUG -- : Resetting attributes to default environment values
D, [2020-07-21T13:33:29.236374 #11357] DEBUG -- : Method: get; URL: https://3.basecampapi.com/4379428/projects
D, [2020-07-21T13:33:29.539547 #11357] DEBUG -- : Access token expired. Please obtain a new access token <------------------
D, [2020-07-21T13:33:29.539587 #11357] DEBUG -- : Update access token using refresh token. <------------------
D, [2020-07-21T13:33:29.798768 #11357] DEBUG -- : Method: get; URL: https://3.basecampapi.com/4379428/projects
Project: Basecamp GitLab/GitHub Integration
```

## Changes

* Remove inheritance between `Client` and `Request` classes. Now, a client will generate a request and retry with a new request if the access token is expired
* Add initial specs for `Request` class
* New `Request::Result` class to inform of the result of a request