### PR TITLE
Update docs for retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ end
 
 For more complex examples, we recommend using a client, instead of the top level `Camp3` wrapper. A `client` has a builtin mechanism to retry requests when the access token has expired and update its information (so it will use the new access token instead of the old one), as oppose to the top level `Camp3` which would request a new access token every time a request were to be made.
 
+Example getting list of TODOs:
+
 ```ruby
 require 'camp3'
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Camp3.configure do |config|
 end
 ```
 
-Example getting list of TODOs
+For more complex examples, we recommend using a client, instead of the top level `Camp3` wrapper. A `client` has a builtin mechanism to retry requests when the access token has expired and update its information (so it will use the new access token instead of the old one), as oppose to the top level `Camp3` which would request a new access token every time a request were to be made.
 
 ```ruby
 require 'camp3'
@@ -51,19 +51,21 @@ Camp3.configure do |config|
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
 
-projects = Camp3.projects
+client = Camp3.client
+
+projects = client.projects
 
 projects.each do |p|
   puts "Project: #{p.inspect}"
 
   puts "Todo set: #{p.todoset.inspect}"
 
-  todoset = Camp3.todoset(p)
+  todoset = client.todoset(p)
 
-  Camp3.todolists(todoset).each do |list|
+  client.todolists(todoset).each do |list|
     puts "Todolist: #{list.title}"
 
-    Camp3.todos(list).each do |todo|
+    client.todos(list).each do |todo|
       puts todo.inspect
     end
   end
@@ -75,6 +77,10 @@ For more examples, check the [examples](examples/) folder
 ## Contributing
 
 Check out the [Contributing](CONTRIBUTING.md) page.
+
+## Changelog
+
+For inspecting the changes and tag releases, check the [Changelog](CHANGELOG.md) page
 
 ## Appreciation
 

--- a/examples/messages.rb
+++ b/examples/messages.rb
@@ -8,15 +8,17 @@ Camp3.configure do |config|
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
 
-projects = Camp3.projects
+client = Camp3.client
+
+projects = client.projects
 
 projects.each do |p|
   puts "Project: #{p.name}"
 
-  message_board = Camp3.message_board(p)
+  message_board = client.message_board(p)
   puts "Message Board: #{message_board.title}"
 
-  messages = Camp3.messages(message_board)
+  messages = client.messages(message_board)
 
   messages.each do |msg|
     puts msg.inspect

--- a/examples/oauth.rb
+++ b/examples/oauth.rb
@@ -6,13 +6,15 @@ Camp3.configure do |config|
     config.redirect_uri = ENV['BASECAMP3_REDIRECT_URI']
 end
 
+client = Camp3.client
+
 # Get the authorization uri
-puts Camp3.authorization_uri
+puts client.authorization_uri
 
 # Once you have received the auth code from basecamp, you can proceed with the following step
 # This will update the configuration with the corresponding tokens
 # Store the tokens in a safe place
-token = Camp3.authorize! ENV['BASECAMP3_ACCESS_CODE']
+token = client.authorize! ENV['BASECAMP3_ACCESS_CODE']
 
 # Print refresh token
 puts token.refresh_token

--- a/examples/todos.rb
+++ b/examples/todos.rb
@@ -8,19 +8,21 @@ Camp3.configure do |config|
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
 
-projects = Camp3.projects
+client = Camp3.client
+
+projects = client.projects
 
 projects.each do |p|
   puts "Project: #{p.inspect}"
 
   puts "Todo set: #{p.todoset.inspect}"
 
-  todoset = Camp3.todoset(p)
+  todoset = client.todoset(p)
 
-  Camp3.todolists(todoset).each do |list|
+  client.todolists(todoset).each do |list|
     puts "Todolist: #{list.title}"
 
-    Camp3.todos(list).each do |todo|
+    client.todos(list).each do |todo|
       puts todo.inspect
     end
   end


### PR DESCRIPTION
## Description

Follow up of #16, so that documentations examples account for the need to use `client` object instead of plain `Camp3` functions