### PR TITLE
Refactor usage around the client object

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camp3 (0.0.2)
+    camp3 (0.0.3)
       httparty (~> 0.18)
       rack-oauth2 (~> 1.14)
 

--- a/README.md
+++ b/README.md
@@ -24,36 +24,52 @@ $ gem install camp3
 
 ## Usage
 
-Configuration example:
+Getting a client and configuring it:
 
 ```ruby
 require 'camp3'
 
-Camp3.configure do |config|
+client = Camp3.client
+
+client.configure do |config|
   config.client_id = ENV['BASECAMP3_CLIENT_ID']
   config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
   config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
   config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
+
+projects = client.projects
 ```
 
-For more complex examples, we recommend using a client, instead of the top level `Camp3` wrapper. A `client` has a builtin mechanism to retry requests when the access token has expired and update its information (so it will use the new access token instead of the old one), as oppose to the top level `Camp3` which would request a new access token every time a request were to be made.
+Alternatively, it is possible to invoke the top-level `#configure` method to get a client:
+
+```ruby
+require 'camp3'
+
+client = Camp3.configure do |config|
+  config.client_id = ENV['BASECAMP3_CLIENT_ID']
+  config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
+  config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
+  config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
+  config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
+end
+
+projects = client.projects
+```
 
 Example getting list of TODOs:
 
 ```ruby
 require 'camp3'
 
-Camp3.configure do |config|
+client = Camp3.configure do |config|
   config.client_id = ENV['BASECAMP3_CLIENT_ID']
   config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
   config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
   config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
-
-client = Camp3.client
 
 projects = client.projects
 
@@ -74,7 +90,7 @@ projects.each do |p|
 end
 ```
 
-For more examples, check the [examples](examples/) folder
+For more examples, check out the [examples](examples/) folder
 
 ## Contributing
 

--- a/examples/messages.rb
+++ b/examples/messages.rb
@@ -1,14 +1,12 @@
 require 'camp3'
 
-Camp3.configure do |config|
+client = Camp3.configure do |config|
   config.client_id = ENV['BASECAMP3_CLIENT_ID']
   config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
   config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
   config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
-
-client = Camp3.client
 
 projects = client.projects
 

--- a/examples/oauth.rb
+++ b/examples/oauth.rb
@@ -1,12 +1,10 @@
 require 'camp3'
 
-Camp3.configure do |config|
+client = Camp3.configure do |config|
     config.client_id = ENV['BASECAMP3_CLIENT_ID']
     config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
     config.redirect_uri = ENV['BASECAMP3_REDIRECT_URI']
 end
-
-client = Camp3.client
 
 # Get the authorization uri
 puts client.authorization_uri

--- a/examples/obtain_acces_token.rb
+++ b/examples/obtain_acces_token.rb
@@ -1,13 +1,13 @@
 require 'camp3'
 
-Camp3.configure do |config|
+client = Camp3.configure do |config|
   config.client_id = ENV['BASECAMP3_CLIENT_ID']
   config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
   config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
   config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
 end
 
-tokens = Camp3.update_access_token!
+tokens = client.update_access_token!
 
 # Prints the new access token
 puts tokens.access_token

--- a/examples/todos.rb
+++ b/examples/todos.rb
@@ -1,14 +1,12 @@
 require 'camp3'
 
-Camp3.configure do |config|
+client = Camp3.configure do |config|
   config.client_id = ENV['BASECAMP3_CLIENT_ID']
   config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
   config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
   config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
   config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
 end
-
-client = Camp3.client
 
 projects = client.projects
 

--- a/lib/camp3.rb
+++ b/lib/camp3.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'forwardable'
 require 'rack/oauth2'
 
 require "camp3/version"
@@ -14,9 +15,6 @@ require "camp3/request"
 require "camp3/client"
 
 module Camp3
-  extend Logging
-  extend Configuration
-
   # Alias for Camp3::Client.new
   #
   # @return [Camp3::Client]
@@ -24,16 +22,11 @@ module Camp3
     Camp3::Client.new(options)
   end
 
-  # Delegate to Camp3::Client
-  def self.method_missing(method, *args, &block)
-    return super unless client.respond_to?(method)
-
-    client.send(method, *args, &block)
-  end
-
-  # Delegate to Camp3::Client
-  def self.respond_to_missing?(method_name, include_private = false)
-    client.respond_to?(method_name) || super
+  # Delegates to Camp3::Client configure method
+  #
+  # @return [Camp3::Client]
+  def self.configure(&block)
+    self.client.configure(&block)
   end
 
 end

--- a/lib/camp3/authorization.rb
+++ b/lib/camp3/authorization.rb
@@ -11,11 +11,11 @@ module Camp3
 
     def authz_client
       Rack::OAuth2::Client.new(
-        identifier: Camp3.client_id,
-        secret: Camp3.client_secret,
-        redirect_uri: Camp3.redirect_uri,
-        authorization_endpoint: Camp3.authz_endpoint,
-        token_endpoint: Camp3.token_endpoint,
+        identifier: @config.client_id,
+        secret: @config.client_secret,
+        redirect_uri: @config.redirect_uri,
+        authorization_endpoint: @config.authz_endpoint,
+        token_endpoint: @config.token_endpoint,
       )
     end
 
@@ -26,10 +26,9 @@ module Camp3
       # Passing secrets as query string
       token = client.access_token!(
         client_auth_method: nil,
-        client_id: Camp3.client_id,
-        client_secret: Camp3.client_secret,
+        client_id: @config.client_id,
+        client_secret: @config.client_secret,
         type: :web_server
-        # code: auth_code
       )
 
       store_tokens(token)
@@ -37,17 +36,16 @@ module Camp3
       token
     end
 
-    def update_access_token!(refresh_token = nil)
-      Camp3.logger.debug "Update access token using refresh token"
+    def update_access_token!
+      logger.debug "Update access token using refresh token"
       
-      refresh_token = Camp3.refresh_token unless refresh_token
       client = authz_client
-      client.refresh_token = refresh_token
+      client.refresh_token = @config.refresh_token
 
       token = client.access_token!(
         client_auth_method: nil,
-        client_id: Camp3.client_id,
-        client_secret: Camp3.client_secret,
+        client_id: @config.client_id,
+        client_secret: @config.client_secret,
         type: :refresh
       )
 
@@ -59,8 +57,8 @@ module Camp3
     private
 
     def store_tokens(token)
-      @access_token = token.access_token
-      @refresh_token = token.refresh_token
+      @config.access_token = token.access_token
+      @config.refresh_token = token.refresh_token
     end
   end
 end

--- a/lib/camp3/configuration.rb
+++ b/lib/camp3/configuration.rb
@@ -28,16 +28,6 @@ module Camp3
       end
     end
 
-    # def configure
-    #   yield self
-    # end
-
-    # # Sets all configuration options to their default values
-    # # when this module is extended.
-    # def self.extended(base)
-    #   base.reset
-    # end
-
     # Creates a hash of options and their values.
     def options
       VALID_OPTIONS_KEYS.inject({}) do |option, key|

--- a/lib/camp3/configuration.rb
+++ b/lib/camp3/configuration.rb
@@ -2,7 +2,7 @@
 
 module Camp3
   # Defines constants and methods related to configuration.
-  module Configuration
+  class Configuration
     include Logging
 
     # An array of valid keys in the options hash when configuring a Basecamp::API.
@@ -22,15 +22,21 @@ module Camp3
     # @private
     attr_accessor(*VALID_OPTIONS_KEYS)
 
-    def configure
-      yield self
+    def initialize(options = {})
+      VALID_OPTIONS_KEYS.each do |key|
+        send("#{key}=", options[key]) if options[key]
+      end
     end
 
-    # Sets all configuration options to their default values
-    # when this module is extended.
-    def self.extended(base)
-      base.reset
-    end
+    # def configure
+    #   yield self
+    # end
+
+    # # Sets all configuration options to their default values
+    # # when this module is extended.
+    # def self.extended(base)
+    #   base.reset
+    # end
 
     # Creates a hash of options and their values.
     def options
@@ -66,6 +72,10 @@ module Camp3
     end
 
     def base_api_endpoint
+      self.class.base_api_endpoint
+    end
+
+    def self.base_api_endpoint
       "https://3.basecampapi.com"
     end
   end

--- a/lib/camp3/logging.rb
+++ b/lib/camp3/logging.rb
@@ -15,7 +15,6 @@ module Camp3
       @logger ||= default_logger
     end
 
-
     private
 
     # Create and configure a logger

--- a/lib/camp3/request.rb
+++ b/lib/camp3/request.rb
@@ -97,7 +97,7 @@ module Camp3
     def extract_parsed(response)
       parsed = response.parsed_response
       
-      parsed.client = self if parsed.respond_to?(:client=)
+      parsed.client = @client if parsed.respond_to?(:client=)
       parsed.parse_headers!(response.headers) if parsed.respond_to?(:parse_headers!)
 
       parsed

--- a/lib/camp3/resource.rb
+++ b/lib/camp3/resource.rb
@@ -63,7 +63,7 @@ module Camp3
 
     def self.detect_type(url)
       case url
-      when /#{Camp3.base_api_endpoint}\/\d+\/projects\/\d+\.json/
+      when /#{Configuration.base_api_endpoint}\/\d+\/projects\/\d+\.json/
         return Project
       else
         return Resource

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Camp3::Authorization do
   before do
-    Camp3.configure do |config|
+    @client = Camp3.configure do |config|
       config.client_id = 'client_id'
       config.client_secret = 'client_secret'
       config.redirect_uri = 'redirect_uri'
@@ -9,7 +9,7 @@ RSpec.describe Camp3::Authorization do
   end
 
   it 'creates authz uri' do
-    uri = Camp3.authorization_uri
+    uri = @client.authorization_uri
 
     expected_uri = 'https://launchpad.37signals.com/authorization/new?'
     expected_uri += 'client_id=client_id&redirect_uri=redirect_uri&response_type=code&type=web_server'

--- a/spec/camp3_spec.rb
+++ b/spec/camp3_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe Camp3 do
       expect(client2.refresh_token).to eq('refresh2')
     end
   end
+
+  describe '#configure' do
+    it 'returns a Camp3::Client' do
+      expect(described_class.configure {}).to be_a Camp3::Client
+    end
+  end
 end

--- a/spec/camp3_spec.rb
+++ b/spec/camp3_spec.rb
@@ -2,4 +2,30 @@ RSpec.describe Camp3 do
   it "has a version number" do
     expect(Camp3::VERSION).not_to be nil
   end
+
+  describe '#client' do 
+    it 'is a Camp3::Client' do
+      expect(described_class.client).to be_a Camp3::Client
+    end
+
+    it 'does not override each other' do
+      client1 = described_class.client(
+        client_id: 'client1', 
+        client_secret: 'secret1', 
+        account_number: '1',
+        refresh_token: 'refresh1'
+      )
+      client2 = described_class.client(
+        client_id: 'client2', 
+        client_secret: 'secret2', 
+        account_number: '2',
+        refresh_token: 'refresh2'
+      )
+
+      expect(client1.api_endpoint).to eq('https://3.basecampapi.com/1')
+      expect(client2.api_endpoint).to eq('https://3.basecampapi.com/2')
+      expect(client1.refresh_token).to eq('refresh1')
+      expect(client2.refresh_token).to eq('refresh2')
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Camp3::Configuration do
 
   context 'using configure helper with all options' do
     before do
-      Camp3.configure do |config|
+      @client = Camp3.configure do |config|
         config.client_id = 'client_id'
         config.client_secret = 'client_secret'
         config.redirect_uri = 'redirect_uri'
@@ -13,44 +13,48 @@ RSpec.describe Camp3::Configuration do
       end
     end
 
+    it 'returns a client object' do
+      expect(@client).to be_a Camp3::Client
+    end
+
     it "sets client_id" do
-      expect(Camp3.client_id).to eq('client_id')
+      expect(@client.client_id).to eq('client_id')
     end
 
     it "sets client_secret" do
-      expect(Camp3.client_secret).to eq('client_secret')
+      expect(@client.client_secret).to eq('client_secret')
     end
 
     it "sets redirect_uri" do
-      expect(Camp3.redirect_uri).to eq('redirect_uri')
+      expect(@client.redirect_uri).to eq('redirect_uri')
     end
 
     it "sets refresh_token" do
-      expect(Camp3.refresh_token).to eq('refresh_token')
+      expect(@client.refresh_token).to eq('refresh_token')
     end
 
     it "sets access_token" do
-      expect(Camp3.access_token).to eq('access_token')
+      expect(@client.access_token).to eq('access_token')
     end
 
     it "sets user_agent" do
-      expect(Camp3.user_agent).to eq('user_agent')
+      expect(@client.user_agent).to eq('user_agent')
     end
 
     it "sets the account number" do
-      expect(Camp3.account_number).to eq('000000')
+      expect(@client.account_number).to eq('000000')
     end
 
     it 'sets the fixed authz endpoint' do 
-      expect(Camp3.authz_endpoint).to eq('https://launchpad.37signals.com/authorization/new')
+      expect(@client.authz_endpoint).to eq('https://launchpad.37signals.com/authorization/new')
     end
 
     it 'sets the fixed token endpoint' do 
-      expect(Camp3.token_endpoint).to eq('https://launchpad.37signals.com/authorization/token')
+      expect(@client.token_endpoint).to eq('https://launchpad.37signals.com/authorization/token')
     end
 
-    it 'sets the fixed api endpoint' do 
-      expect(Camp3.api_endpoint).to eq('https://3.basecampapi.com/000000')
+    it 'sets the api endpoint' do 
+      expect(@client.api_endpoint).to eq('https://3.basecampapi.com/000000')
     end
   end
 end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,5 +1,9 @@
 RSpec.describe Camp3::Logging do
-  it 'should have a default logger' do
-    expect(Camp3.logger).to be_an_instance_of(Logger)
+  before do 
+    @client = Camp3.client
+  end
+  
+  it 'a client should have a default logger' do
+    expect(@client.logger).to be_an_instance_of(Logger)
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Camp3::Request do
       body = JSON.unparse(a: 1, b: 2)
       expect(described_class.parse(body)).to be_an Camp3::Resource
       expect(described_class.parse('true')).to be true
-      expect(described_class.parse('false', )).to be false
-
+      expect(described_class.parse('false')).to be false
       expect { described_class.parse('string') }.to raise_error(Camp3::Error::Parsing)
     end
   end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Camp3::Request do
   before do
-    @request = described_class.new('token', 'user-agent')
+    @request = described_class.new('token', 'user-agent', Camp3.client)
   end
 
   it { expect(@request).to respond_to :get }
@@ -34,7 +34,7 @@ RSpec.describe Camp3::Request do
 
   describe '#authorization_header' do
     it 'raises MissingCredentials when access_token is not set' do
-      request = described_class.new('', 'user-agent')
+      request = described_class.new('', 'user-agent', Camp3.client)
       expect do
         request.send(:authorization_header)
       end.to raise_error(Camp3::Error::MissingCredentials)

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Camp3::Request do
       body = JSON.unparse(a: 1, b: 2)
       expect(described_class.parse(body)).to be_an Camp3::Resource
       expect(described_class.parse('true')).to be true
-      expect(described_class.parse('false')).to be false
+      expect(described_class.parse('false', )).to be false
 
       expect { described_class.parse('string') }.to raise_error(Camp3::Error::Parsing)
     end


### PR DESCRIPTION
## Description

Based on the initial implementation, we were allowing access to the `client` object methods from the top-level `Camp3` module. That is not a recommended practice in our case due to the need of refreshing the `access_token` associated with a given `client`. With that in mind, this PR removes the ability to access the client functionality from the top-level `Camp3` module, it is now required to instantiate a `client` object first.

## Changes

* Replaced references to configuration properties from `Camp3` with the equivalent `client` object invocation

### Configuration

* Configuration becomes a class instead of a module

### Client class

* Add `config` instance variable
* New `configure` method to allow initialize the `config` instance variable with a block
* Allow access to configuration properties by delegating to the `config` instance var using `Forwardable` module

### Request class

* It receives now the parent client that triggered the request

### Camp3 module

* Remove `Logging` and `Configuration` extends statements
* Remove `method_missing` and `respond_to`
* Add new `configure` method to connect with the `client#configure` method

### Documentation

* Update README
* Update examples