### PR TITLE
Add Comment API Module

### DIFF
--- a/examples/comments.rb
+++ b/examples/comments.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'camp3'
+
+client = Camp3.configure do |config|
+  config.client_id = ENV['BASECAMP3_CLIENT_ID']
+  config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
+  config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
+  config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
+  config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
+end
+
+projects = client.projects
+
+projects.each do |p|
+  puts "Project: #{p.name}"
+
+  message_board = client.message_board(p)
+  todoset = client.todoset(p)
+
+  # Message board and Todo set are example resources that doesn't have comments
+  puts "Message Board: #{message_board.title}, can be commented on: #{message_board.can_be_commented?}"
+  puts "Todo set: #{todoset.title}, can be commented on: #{todoset.can_be_commented?}"
+
+  # Adds a comment on the first todolist
+  list = client.todolists(todoset).first
+  puts "Todolist: #{list.title}, can be commented on: #{list.can_be_commented?}"
+  client.add_comment(list, 'New <b>comment</b> with <i>HTML support</i>')
+  comments = client.comments(list)
+  comments.each do |c|
+    puts "Comment content: #{c.content}"
+  end
+end

--- a/lib/camp3/api/comment.rb
+++ b/lib/camp3/api/comment.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Camp3::Client
+  module CommentAPI
+    def add_comment(resource, content)
+      post(resource.comments_url, override_path: true, body: { content: content }.to_json)
+    end
+
+    def comments(resource)
+      get(resource.comments_url, override_path: true)
+    end
+  end
+end

--- a/lib/camp3/client.rb
+++ b/lib/camp3/client.rb
@@ -12,6 +12,7 @@ module Camp3
 
     # Keep in alphabetical order
     include Authorization
+    include CommentAPI
     include Logging
     include MessageAPI
     include ProjectAPI

--- a/lib/camp3/configuration.rb
+++ b/lib/camp3/configuration.rb
@@ -23,6 +23,7 @@ module Camp3
     attr_accessor(*VALID_OPTIONS_KEYS)
 
     def initialize(options = {})
+      options[:user_agent] ||= DEFAULT_USER_AGENT
       VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key]) if options[key]
       end

--- a/lib/camp3/request.rb
+++ b/lib/camp3/request.rb
@@ -8,7 +8,7 @@ module Camp3
     include HTTParty
     include Logging
     format :json
-    headers 'Accept' => 'application/json'
+    headers 'Accept' => 'application/json', 'Content-Type' => 'application/json'
     parser(proc { |body, _| parse(body) })
 
     module Result
@@ -67,6 +67,7 @@ module Camp3
 
     # Executes the request
     def execute_request(method, endpoint, params)
+      params[:headers].merge!(self.class.headers)
       params[:headers].merge!(authorization_header)
       
       logger.debug("Method: #{method}; URL: #{endpoint}")

--- a/lib/camp3/resource.rb
+++ b/lib/camp3/resource.rb
@@ -24,6 +24,14 @@ module Camp3
       data[key]
     end
 
+    # Check whether a resource can be commented on or not
+    # given the presences of `comments_count` and `comments_url` keys
+    #
+    # @return [Boolean]
+    def can_be_commented?
+      hash.key?('comments_url') && hash.key?('comments_count')
+    end
+
     private
 
     attr_reader :hash, :data

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Camp3::Request do
       default_options = described_class.default_options
       expect(default_options).to be_a Hash
       expect(default_options[:format]).to eq(:json)
-      expect(default_options[:headers]).to eq({'Accept' => 'application/json', 'User-Agent' => 'user-agent'})
+      expect(default_options[:headers]).to eq({ 'Accept' => 'application/json', 'Content-Type' => 'application/json', 'User-Agent' => 'user-agent' })
     end
   end
 


### PR DESCRIPTION
## Description

Fix #11 

Adds `CommentAPI` module to fetch and create comments for any given `Resource`.

### Example Usage

```ruby
require 'camp3'

client = Camp3.configure do |config|
  config.client_id = ENV['BASECAMP3_CLIENT_ID']
  config.client_secret = ENV['BASECAMP3_CLIENT_SECRET']
  config.account_number = ENV['BASECAMP3_ACCOUNT_NUMBER']
  config.refresh_token = ENV['BASECAMP3_REFRESH_TOKEN']
  config.access_token = ENV['BASECAMP3_ACCESS_TOKEN']
end

# Resource from URL
resource = client.resource('YOUR_RESOURCE_URL')
if resource.can_be_commented?
  client.add_comment(resouce, 'Hello camp3, nice project!')
  comments = client.comments(resouce)
  comments.each do |c|
    puts "#{c.content}"
  end
end
```

For more examples check **./examples/comments.rb*

## Changes

 * Added method `can_be_commented?` to check whether a resource can be commented or not
 * Fix: Added `'Content-Type' => 'application/json'` request header and updating its values before doing any request
 * Fix: Initializing default `user_agent` with `DEFAULT_USER_AGENT` in `Configuration.new` constructor
 * Added `CommentAPI` module with `comments` and `add_comment` methods